### PR TITLE
3.1.0+10.24.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+---
+# This workflow requires a GALAXY_API_KEY secret present in the GitHub
+# repository or organization.
+#
+# See: https://github.com/marketplace/actions/publish-ansible-role-to-galaxy
+# See: https://github.com/ansible/galaxy/issues/46
+
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: 'githubixx.traefik_kubernetes'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'githubixx.traefik_kubernetes'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible.
+        run: pip3 install ansible-core
+
+      - name: Trigger a new import on Galaxy.
+        run: >-
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - update Helm chart to `v10.24.4`
 - use Traefik `v2.8.7`
+- add Github release action to push new release to Ansible Galaxy
 
 ## 3.0.0+10.24.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.0+10.24.4
+
+- update Helm chart to `v10.24.4`
+- use Traefik `v2.8.7`
+
 ## 3.0.0+10.24.2
 
 - update Helm chart to `v10.24.2`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-traefik_chart_version: "10.24.2"
+traefik_chart_version: "10.24.4"
 
 # Helm release name
 traefik_release_name: "traefik"
@@ -114,7 +114,7 @@ The first thing to do is to check `templates/traefik_values_default.yml.j2`. Thi
 
 image:
   name: traefik
-  tag: "2.8.4"
+  tag: "2.8.7"
   pullPolicy: IfNotPresent
 
 # These arguments are passed to Traefik's binary. For all options see:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-traefik_chart_version: "10.24.2"
+traefik_chart_version: "10.24.4"
 
 # Helm release name
 traefik_release_name: "traefik"

--- a/templates/traefik_values_default.yml.j2
+++ b/templates/traefik_values_default.yml.j2
@@ -3,7 +3,7 @@
 
 image:
   name: traefik
-  tag: "2.8.4"
+  tag: "2.8.7"
   pullPolicy: IfNotPresent
 
 # These arguments are passed to Traefik's binary. For all options see:


### PR DESCRIPTION
- update Helm chart to `v10.24.4`
- use Traefik `v2.8.7`
- add Github release action to push new release to Ansible Galaxy