### PR TITLE
5.1.0+23.1.0

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,9 @@
 ---
 extends: default
 
+ignore: |
+  files/crds/
+
 rules:
   line-length:
     max: 300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.1.0+23.1.0
+
+- update Helm chart to version `23.1.0`
+- update Traefik from version `2.10.1` to `2.10.4`
+- `.yamllint`: ignore `files/crds/` directory
+- fix ansible-lint issues
+
 ## 5.0.0+23.0.1
 
 **Important note:** This release updates Traefik Helm chart from version `16.2.0` to `23.0.1`. Please read the following release notes carefully if you upgrade as it contains breaking changes esp. from chart version `16.x` to `17.x`:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-traefik_chart_version: "23.0.1"
+traefik_chart_version: "23.1.0"
 
 # Helm release name
 traefik_release_name: "traefik"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The first thing to do is to check `templates/traefik_values_default.yml.j2`. Thi
 
 image:
   repository: traefik
-  tag: "2.10.1"
+  tag: "2.10.4"
   pullPolicy: IfNotPresent
 
 # These arguments are passed to Traefik's binary. For all options see:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-traefik_chart_version: "23.0.1"
+traefik_chart_version: "23.1.0"
 
 # Helm release name
 traefik_release_name: "traefik"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,7 @@
 ---
 - name: Include prerequisites
-  include_tasks: "tasks/prerequisites.yml"
+  ansible.builtin.include_tasks:
+    file: "tasks/prerequisites.yml"
 
 - name: Render values
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,4 +41,4 @@
     - '"delete" in action'
 
 - name: Include tasks to execute requested action
-  ansible.builtin.include_tasks: "tasks/{{ deploy_action|lower }}.yml"
+  ansible.builtin.include_tasks: "tasks/{{ deploy_action | lower }}.yml"

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure namespace
-  k8s:
+  kubernetes.core.k8s:
     name: "{{ traefik_namespace }}"
     api_version: v1
     kind: Namespace

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -1,6 +1,7 @@
 ---
 - name: Include prerequisites
-  include_tasks: "tasks/prerequisites.yml"
+  ansible.builtin.include_tasks:
+    file: "tasks/prerequisites.yml"
 
 - name: Render values
   block:

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -1,6 +1,7 @@
 ---
 - name: Include prerequisites
-  include_tasks: "tasks/prerequisites.yml"
+  ansible.builtin.include_tasks:
+    file: "tasks/prerequisites.yml"
 
 - name: Render values
   block:

--- a/templates/traefik_values_default.yml.j2
+++ b/templates/traefik_values_default.yml.j2
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: traefik
-  tag: "2.10.1"
+  tag: "2.10.4"
   pullPolicy: IfNotPresent
 
 # These arguments are passed to Traefik's binary. For all options see:


### PR DESCRIPTION
- update Helm chart to version `23.1.0`
- update Traefik from version `2.10.1` to `2.10.4`
- `.yamllint`: ignore `files/crds/` directory
- fix ansible-lint issues
