### PR TITLE
6.0.0+23.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,4 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 5.1.2+23.1.0
+## 6.0.0+23.2.0
+
+- **POTENTIALLY BREAKING**: add `updateStrategy` to `templates/traefik_values_default.yml.j2`. This differs from the default [values.yaml](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml). Setting `maxUnavailable: 1` and removing `maxSurge: 1` to make rolling update work with the default `DaemonSet`
+- update Helm chart to version `23.2.0`
+- update Traefik from version `2.10.7` to `2.11.0`
+- update Github workflow
+
+## 5.1.3+23.1.0
 
 - update Traefik from version `2.10.4` to `2.10.7`
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ resources:
   limits:
     cpu: "300m"
     memory: "150Mi"
+
+# Updates the Pods in the DaemonSet one by one when the DaemonSet was upgraded
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
 ```
 
 But nothing is made in stone ;-) To use your own values just create a file called `values.yml.j2` or `values.yaml.j2` and put it into the directory specified in `traefik_chart_values_directory` (which is `$HOME/traefik/helm` by default). Then this role will use that file to render the Helm values. You can use `templates/traefik_values_default.yml.j2` as a template or just start from scratch. As mentioned above you can modify all settings for the Helm chart that are different to the default ones which are located [here](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Role Variables
 
 ```yaml
 # Helm chart version
-traefik_chart_version: "23.1.0"
+traefik_chart_version: "23.2.0"
 
 # Helm release name
 traefik_release_name: "traefik"
@@ -123,7 +123,7 @@ The first thing to do is to check `templates/traefik_values_default.yml.j2`. Thi
 
 image:
   repository: traefik
-  tag: "2.10.7"
+  tag: "2.11.0"
   pullPolicy: IfNotPresent
 
 # These arguments are passed to Traefik's binary. For all options see:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Helm chart version
-traefik_chart_version: "23.1.0"
+traefik_chart_version: "23.2.0"
 
 # Helm release name
 traefik_release_name: "traefik"

--- a/templates/traefik_values_default.yml.j2
+++ b/templates/traefik_values_default.yml.j2
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: traefik
-  tag: "2.10.7"
+  tag: "2.11.0"
   pullPolicy: IfNotPresent
 
 # These arguments are passed to Traefik's binary. For all options see:

--- a/templates/traefik_values_default.yml.j2
+++ b/templates/traefik_values_default.yml.j2
@@ -115,3 +115,8 @@ resources:
     cpu: "300m"
     memory: "150Mi"
 
+# Updates the Pods in the DaemonSet one by one when the DaemonSet was upgraded
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1


### PR DESCRIPTION
- **POTENTIALLY BREAKING**: add `updateStrategy` to `templates/traefik_values_default.yml.j2`. This differs from the default [values.yaml](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml). Setting `maxUnavailable: 1` and removing `maxSurge: 1` to make rolling update work with the default `DaemonSet`
- update Helm chart to version `23.2.0`
- update Traefik from version `2.10.7` to `2.11.0`
- update Github workflow